### PR TITLE
Use consul node adress if service addr is empty

### DIFF
--- a/resec/consul/manager.go
+++ b/resec/consul/manager.go
@@ -336,7 +336,14 @@ func (m *Manager) watchConsulMasterService() {
 				continue
 			}
 
-			m.state.MasterAddr = master.Service.Address
+			// handle If master is registred in consul with port only
+			// Use node IP insted of service IP
+			if master.Service.Address != "" {
+				m.state.MasterAddr = master.Service.Address
+			} else {
+				m.state.MasterAddr = master.Node.Address
+			}
+
 			m.state.MasterPort = master.Service.Port
 			m.emit()
 

--- a/resec/consul/new.go
+++ b/resec/consul/new.go
@@ -57,6 +57,7 @@ func NewConnection(c *cli.Context, redisConfig redis.Config) (*Manager, error) {
 	if announceAddr == "" {
 		redisHost := strings.Split(redisConfig.Address, ":")[0]
 		redisPort := strings.Split(redisConfig.Address, ":")[1]
+		// If REDIS_ADDR is declared as localhost register only port, and rely on consul to bring the agents IP
 		if redisHost == "127.0.0.1" || redisHost == "localhost" || redisHost == "::1" {
 			consulConfig.announceAddr = ":" + redisPort
 		} else {


### PR DESCRIPTION
Example if REDIS_ADDR is 127.0.0.1 no IP will be registred in consul