### PR TITLE
fix: ANNOUNCE_ADDR not being passed to consulConfig.announceAddr

### DIFF
--- a/resec/consul/new.go
+++ b/resec/consul/new.go
@@ -63,6 +63,8 @@ func NewConnection(c *cli.Context, redisConfig redis.Config) (*Manager, error) {
 		} else {
 			consulConfig.announceAddr = redisConfig.Address
 		}
+	} else {
+		consulConfig.announceAddr = announceAddr
 	}
 
 	var err error


### PR DESCRIPTION
if ANNOUNCE_ADDR was set, resec would crash with "panic: runtime error: index out of range [1] with length 1"